### PR TITLE
Fix: Apply Rubocop formatting to `app` directory

### DIFF
--- a/app/channels/application_cable/channel.rb
+++ b/app/channels/application_cable/channel.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ApplicationCable
   class Channel < ActionCable::Channel::Base
   end

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ApplicationCable
   class Connection < ActionCable::Connection::Base
   end

--- a/app/components/blacklight/facet_field_pagination_component.rb
+++ b/app/components/blacklight/facet_field_pagination_component.rb
@@ -1,8 +1,6 @@
-=begin
-Origin: https://github.com/projectblacklight/blacklight/blob/v7.37.0/app/components/blacklight/facet_field_pagination_component.rb
-
-Re-defines Blacklight's FacetFieldPaginationComponent class so we can override its corresponding template. No changes/overrides made to this file other than adding comments.
-=end
+# Origin: https://github.com/projectblacklight/blacklight/blob/v7.37.0/app/components/blacklight/facet_field_pagination_component.rb
+#
+# Re-defines Blacklight's FacetFieldPaginationComponent class so we can override its corresponding template. No changes/overrides made to this file other than adding comments.
 
 # frozen_string_literal: true
 

--- a/app/components/blacklight/search_context_component.rb
+++ b/app/components/blacklight/search_context_component.rb
@@ -1,9 +1,7 @@
-=begin
-Origin: https://github.com/projectblacklight/blacklight/blob/v7.37.0/app/components/blacklight/search_context_component.rb
-
-Re-defines and overrides Blacklight's SearchContextComponent class to call ual_link_to_previous_document and ual_link_to_next_document, so that we can modify it to use the appropriate markup.
-ual_link_to_previous_document and ual_link_to_next_document are defined in application_helper.rb.
-=end
+# Origin: https://github.com/projectblacklight/blacklight/blob/v7.37.0/app/components/blacklight/search_context_component.rb
+#
+# Re-defines and overrides Blacklight's SearchContextComponent class to call ual_link_to_previous_document and ual_link_to_next_document, so that we can modify it to use the appropriate markup.
+# ual_link_to_previous_document and ual_link_to_next_document are defined in application_helper.rb.
 
 # frozen_string_literal: true
 

--- a/app/components/blacklight/start_over_button_component.rb
+++ b/app/components/blacklight/start_over_button_component.rb
@@ -1,15 +1,14 @@
-=begin
-Origin: https://github.com/projectblacklight/blacklight/blob/v7.37.0/app/components/blacklight/start_over_button_component.rb
-
-Re-defines and overrides Blacklight's StartOverButtonComponent class to add AZ Bootstrap classes and add html_safe for use of icons.
-=end
+# Origin: https://github.com/projectblacklight/blacklight/blob/v7.37.0/app/components/blacklight/start_over_button_component.rb
+#
+# Re-defines and overrides Blacklight's StartOverButtonComponent class to add AZ Bootstrap classes and add html_safe for use of icons.
 
 # frozen_string_literal: true
 
 module Blacklight
   class StartOverButtonComponent < Blacklight::Component
     def call
-      link_to t('blacklight.search.start_over').html_safe, start_over_path, class: 'catalog_startOverLink btn btn-outline-blue'
+      link_to t('blacklight.search.start_over').html_safe, start_over_path,
+              class: 'catalog_startOverLink btn btn-outline-blue'
     end
 
     private
@@ -17,7 +16,7 @@ module Blacklight
     ##
     # Get the path to the search action with any parameters (e.g. view type)
     # that should be persisted across search sessions.
-    def start_over_path query_params = params
+    def start_over_path(query_params = params)
       Deprecation.silence(Blacklight::UrlHelperBehavior) do
         helpers.start_over_path(query_params)
       end

--- a/app/components/geoblacklight/homepage_feature_facet_component.rb
+++ b/app/components/geoblacklight/homepage_feature_facet_component.rb
@@ -1,8 +1,6 @@
-=begin
-Origin: https://github.com/geoblacklight/geoblacklight/blob/v4.4.0/app/components/geoblacklight/homepage_feature_facet_component.rb
-
-Re-defines GeoBlacklight's HomepageFeatureFacetComponent class so we can override its corresponding template. No changes/overrides made to this file other than adding comments.
-=end
+# Origin: https://github.com/geoblacklight/geoblacklight/blob/v4.4.0/app/components/geoblacklight/homepage_feature_facet_component.rb
+#
+# Re-defines GeoBlacklight's HomepageFeatureFacetComponent class so we can override its corresponding template. No changes/overrides made to this file other than adding comments.
 
 # frozen_string_literal: true
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,14 +1,16 @@
+# frozen_string_literal: true
+
 class ApplicationController < ActionController::Base
   # Adds a few additional behaviors into the application controller
   include Blacklight::Controller
   layout :determine_layout if respond_to? :layout
 
-        before_action :allow_geoblacklight_params
+  before_action :allow_geoblacklight_params
 
-        def allow_geoblacklight_params
-          # Blacklight::Parameters will pass these to params.permit
-          blacklight_config.search_state_fields.append(Settings.GBL_PARAMS)
-        end
+  def allow_geoblacklight_params
+    # Blacklight::Parameters will pass these to params.permit
+    blacklight_config.search_state_fields.append(Settings.GBL_PARAMS)
+  end
 
   # Status page for Pingdom
   def status

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 class CatalogController < ApplicationController
   include Blacklight::Catalog
-  
+
   configure_blacklight do |config|
     # Ensures that JSON representations of Solr Documents can be retrieved using
     # the path /catalog/:id/raw
@@ -12,7 +14,7 @@ class CatalogController < ApplicationController
     ## @see https://lucene.apache.org/solr/guide/6_6/the-dismax-query-parser.html#TheDisMaxQueryParser-Theq.altParameter
     config.default_solr_params = {
       :start => 0,
-      "q.alt" => "*:*"
+      'q.alt' => '*:*'
     }
 
     ## Default rows returned from Solr
@@ -23,14 +25,14 @@ class CatalogController < ApplicationController
     ## parameters included in the Blacklight-jetty document requestHandler.
     #
     config.default_document_solr_params = {
-      qt: "document",
+      qt: 'document',
       q: "{!raw f=#{Settings.FIELDS.ID} v=$id}"
     }
 
     # GeoBlacklight Defaults
     # * Adds the "map" split view for catalog#index
-    config.view.split(partials: ["index"])
-    config.view.delete_field("list")
+    config.view.split(partials: ['index'])
+    config.view.delete_field('list')
 
     # solr field configuration for search results/index views
     # config.index.show_link = 'title_display'
@@ -42,12 +44,12 @@ class CatalogController < ApplicationController
     # This sets the metadata to display below the map viewer.
     # To move metadata above the map viewer,
     # remove the lines deleting and re-adding the :show partial
-    config.show.display_type_field = "format"
+    config.show.display_type_field = 'format'
     config.show.partials.delete(:show)
-    config.show.partials << "show_default_display_note"
-    config.show.partials << "show_default_viewer_container"
-    config.show.partials << "show_default_attribute_table"
-    config.show.partials << "show_default_viewer_information"
+    config.show.partials << 'show_default_display_note'
+    config.show.partials << 'show_default_viewer_container'
+    config.show.partials << 'show_default_attribute_table'
+    config.show.partials << 'show_default_viewer_information'
     config.show.partials << :show
 
     ##
@@ -92,18 +94,20 @@ class CatalogController < ApplicationController
 
     # DEFAULT FACETS
     # to add additional facets, use the keys defined in the settings.yml file
-    config.add_facet_field Settings.FIELDS.INDEX_YEAR, label: "Year", limit: 10
-    config.add_facet_field Settings.FIELDS.SPATIAL_COVERAGE, label: "Place", limit: 8
-    config.add_facet_field Settings.FIELDS.ACCESS_RIGHTS, label: "Access", limit: 8, item_component: Geoblacklight::IconFacetItemComponent
-    config.add_facet_field Settings.FIELDS.RESOURCE_CLASS, label: "Resource Class", limit: 8
-    config.add_facet_field Settings.FIELDS.RESOURCE_TYPE, label: "Resource Type", limit: 8
-    config.add_facet_field Settings.FIELDS.FORMAT, label: "Format", limit: 8
-    config.add_facet_field Settings.FIELDS.SUBJECT, label: "Subject", limit: 8
-    config.add_facet_field Settings.FIELDS.THEME, label: "Theme", limit: 8
-    config.add_facet_field Settings.FIELDS.CREATOR, label: "Creator", limit: 8
-    config.add_facet_field Settings.FIELDS.PUBLISHER, label: "Publisher", limit: 8
-    config.add_facet_field Settings.FIELDS.PROVIDER, label: "Provider", limit: 8, item_component: Geoblacklight::IconFacetItemComponent
-    config.add_facet_field Settings.FIELDS.GEOREFERENCED, label: "Georeferenced", limit: 3
+    config.add_facet_field Settings.FIELDS.INDEX_YEAR, label: 'Year', limit: 10
+    config.add_facet_field Settings.FIELDS.SPATIAL_COVERAGE, label: 'Place', limit: 8
+    config.add_facet_field Settings.FIELDS.ACCESS_RIGHTS, label: 'Access', limit: 8,
+                                                          item_component: Geoblacklight::IconFacetItemComponent
+    config.add_facet_field Settings.FIELDS.RESOURCE_CLASS, label: 'Resource Class', limit: 8
+    config.add_facet_field Settings.FIELDS.RESOURCE_TYPE, label: 'Resource Type', limit: 8
+    config.add_facet_field Settings.FIELDS.FORMAT, label: 'Format', limit: 8
+    config.add_facet_field Settings.FIELDS.SUBJECT, label: 'Subject', limit: 8
+    config.add_facet_field Settings.FIELDS.THEME, label: 'Theme', limit: 8
+    config.add_facet_field Settings.FIELDS.CREATOR, label: 'Creator', limit: 8
+    config.add_facet_field Settings.FIELDS.PUBLISHER, label: 'Publisher', limit: 8
+    config.add_facet_field Settings.FIELDS.PROVIDER, label: 'Provider', limit: 8,
+                                                     item_component: Geoblacklight::IconFacetItemComponent
+    config.add_facet_field Settings.FIELDS.GEOREFERENCED, label: 'Georeferenced', limit: 3
 
     # GEOBLACKLIGHT APPLICATION FACETS
 
@@ -112,19 +116,20 @@ class CatalogController < ApplicationController
     # filter_query_builder - Defines the query generated for Solr
     # filter_class         - Defines how to add/remove facet from query
     # label                - Defines the label used in contstraints container
-    config.add_facet_field Settings.FIELDS.GEOMETRY, item_presenter: Geoblacklight::BboxItemPresenter, filter_class: Geoblacklight::BboxFilterField, filter_query_builder: Geoblacklight::BboxFilterQuery, within_boost: Settings.BBOX_WITHIN_BOOST, overlap_boost: Settings.OVERLAP_RATIO_BOOST, overlap_field: Settings.FIELDS.OVERLAP_FIELD, label: "Bounding Box"
+    config.add_facet_field Settings.FIELDS.GEOMETRY, item_presenter: Geoblacklight::BboxItemPresenter,
+                                                     filter_class: Geoblacklight::BboxFilterField, filter_query_builder: Geoblacklight::BboxFilterQuery, within_boost: Settings.BBOX_WITHIN_BOOST, overlap_boost: Settings.OVERLAP_RATIO_BOOST, overlap_field: Settings.FIELDS.OVERLAP_FIELD, label: 'Bounding Box'
 
     # Item Relationship Facets
     # * Not displayed to end user (show: false)
     # * Must be present for relationship "Browse all 4 records" links to work
     # * Label value becomes the search contraint filter name
-    config.add_facet_field Settings.FIELDS.MEMBER_OF, label: "Member Of", show: false
-    config.add_facet_field Settings.FIELDS.IS_PART_OF, label: "Is Part Of", show: false
-    config.add_facet_field Settings.FIELDS.RELATION, label: "Related", show: false
-    config.add_facet_field Settings.FIELDS.REPLACES, label: "Replaces", show: false
-    config.add_facet_field Settings.FIELDS.IS_REPLACED_BY, label: "Is Replaced By", show: false
-    config.add_facet_field Settings.FIELDS.SOURCE, label: "Source", show: false
-    config.add_facet_field Settings.FIELDS.VERSION, label: "Is Version Of", show: false
+    config.add_facet_field Settings.FIELDS.MEMBER_OF, label: 'Member Of', show: false
+    config.add_facet_field Settings.FIELDS.IS_PART_OF, label: 'Is Part Of', show: false
+    config.add_facet_field Settings.FIELDS.RELATION, label: 'Related', show: false
+    config.add_facet_field Settings.FIELDS.REPLACES, label: 'Replaces', show: false
+    config.add_facet_field Settings.FIELDS.IS_REPLACED_BY, label: 'Is Replaced By', show: false
+    config.add_facet_field Settings.FIELDS.SOURCE, label: 'Source', show: false
+    config.add_facet_field Settings.FIELDS.VERSION, label: 'Is Version Of', show: false
 
     # Have BL send all facet field names to Solr, which has been the default
     # previously. Simply remove these lines if you'd rather use Solr request
@@ -156,28 +161,30 @@ class CatalogController < ApplicationController
     # The following fields all feature string values. If there is a value present in the metadata, they fields will show up on the item show page.
     # The labels and order can be customed. Comment out fields to hide them.
 
-    config.add_show_field Settings.FIELDS.ALTERNATIVE_TITLE, label: "Alternative Title", itemprop: "alt_title"
-    config.add_show_field Settings.FIELDS.DESCRIPTION, label: "Description", itemprop: "description", helper_method: :render_value_as_truncate_abstract
-    config.add_show_field Settings.FIELDS.CREATOR, label: "Creator", itemprop: "creator"
-    config.add_show_field Settings.FIELDS.PUBLISHER, label: "Publisher", itemprop: "publisher"
-    config.add_show_field Settings.FIELDS.PROVIDER, label: "Provider", link_to_facet: true
-    config.add_show_field Settings.FIELDS.RESOURCE_CLASS, label: "Resource Class", itemprop: "class"
-    config.add_show_field Settings.FIELDS.RESOURCE_TYPE, label: "Resource Type", itemprop: "type"
-    config.add_show_field Settings.FIELDS.SUBJECT, label: "Subject", itemprop: "keywords", link_to_facet: true
-    config.add_show_field Settings.FIELDS.THEME, label: "Theme", itemprop: "theme"
-    config.add_show_field Settings.FIELDS.TEMPORAL_COVERAGE, label: "Temporal Coverage", itemprop: "temporal"
-    config.add_show_field Settings.FIELDS.DATE_ISSUED, label: "Date Issued", itemprop: "issued"
-    config.add_show_field Settings.FIELDS.SPATIAL_COVERAGE, label: "Spatial Coverage", itemprop: "spatial", link_to_facet: true
-    config.add_show_field Settings.FIELDS.RIGHTS, label: "Rights", itemprop: "rights"
-    config.add_show_field Settings.FIELDS.RIGHTS_HOLDER, label: "Rights Holder", itemprop: "rights_holder"
-    config.add_show_field Settings.FIELDS.LICENSE, label: "License", itemprop: "license"
-    config.add_show_field Settings.FIELDS.ACCESS_RIGHTS, label: "Access Rights", itemprop: "access_rights"
-    config.add_show_field Settings.FIELDS.FORMAT, label: "Format", itemprop: "format"
-    config.add_show_field Settings.FIELDS.FILE_SIZE, label: "File Size", itemprop: "file_size"
-    config.add_show_field Settings.FIELDS.GEOREFERENCED, label: "Georeferenced", itemprop: "georeferenced"
+    config.add_show_field Settings.FIELDS.ALTERNATIVE_TITLE, label: 'Alternative Title', itemprop: 'alt_title'
+    config.add_show_field Settings.FIELDS.DESCRIPTION, label: 'Description', itemprop: 'description',
+                                                       helper_method: :render_value_as_truncate_abstract
+    config.add_show_field Settings.FIELDS.CREATOR, label: 'Creator', itemprop: 'creator'
+    config.add_show_field Settings.FIELDS.PUBLISHER, label: 'Publisher', itemprop: 'publisher'
+    config.add_show_field Settings.FIELDS.PROVIDER, label: 'Provider', link_to_facet: true
+    config.add_show_field Settings.FIELDS.RESOURCE_CLASS, label: 'Resource Class', itemprop: 'class'
+    config.add_show_field Settings.FIELDS.RESOURCE_TYPE, label: 'Resource Type', itemprop: 'type'
+    config.add_show_field Settings.FIELDS.SUBJECT, label: 'Subject', itemprop: 'keywords', link_to_facet: true
+    config.add_show_field Settings.FIELDS.THEME, label: 'Theme', itemprop: 'theme'
+    config.add_show_field Settings.FIELDS.TEMPORAL_COVERAGE, label: 'Temporal Coverage', itemprop: 'temporal'
+    config.add_show_field Settings.FIELDS.DATE_ISSUED, label: 'Date Issued', itemprop: 'issued'
+    config.add_show_field Settings.FIELDS.SPATIAL_COVERAGE, label: 'Spatial Coverage', itemprop: 'spatial',
+                                                            link_to_facet: true
+    config.add_show_field Settings.FIELDS.RIGHTS, label: 'Rights', itemprop: 'rights'
+    config.add_show_field Settings.FIELDS.RIGHTS_HOLDER, label: 'Rights Holder', itemprop: 'rights_holder'
+    config.add_show_field Settings.FIELDS.LICENSE, label: 'License', itemprop: 'license'
+    config.add_show_field Settings.FIELDS.ACCESS_RIGHTS, label: 'Access Rights', itemprop: 'access_rights'
+    config.add_show_field Settings.FIELDS.FORMAT, label: 'Format', itemprop: 'format'
+    config.add_show_field Settings.FIELDS.FILE_SIZE, label: 'File Size', itemprop: 'file_size'
+    config.add_show_field Settings.FIELDS.GEOREFERENCED, label: 'Georeferenced', itemprop: 'georeferenced'
     config.add_show_field(
       Settings.FIELDS.REFERENCES,
-      label: "More details at",
+      label: 'More details at',
       accessor: [:external_url],
       if: proc { |_, _, doc| doc.external_url },
       helper_method: :render_references_url
@@ -229,7 +236,7 @@ class CatalogController < ApplicationController
     # solr request handler? The one set in config[:default_solr_parameters][:qt],
     # since we aren't specifying it otherwise.
 
-    config.add_search_field "all_fields", label: "All Fields"
+    config.add_search_field 'all_fields', label: 'All Fields'
     # config.add_search_field 'dct_title_ti', :label => 'Title'
     # config.add_search_field 'dct_description_ti', :label => 'Description'
 
@@ -283,11 +290,11 @@ class CatalogController < ApplicationController
     # label in pulldown is followed by the name of the SOLR field to sort by and
     # whether the sort is ascending or descending (it must be asc or desc
     # except in the relevancy case).
-    config.add_sort_field "score desc, dct_title_sort asc", label: "Relevance"
-    config.add_sort_field "#{Settings.FIELDS.INDEX_YEAR} desc, dct_title_sort asc", label: "Year (Newest first)"
-    config.add_sort_field "#{Settings.FIELDS.INDEX_YEAR} asc, dct_title_sort asc", label: "Year (Oldest first)"
-    config.add_sort_field "dct_title_sort asc", label: "Title (A-Z)"
-    config.add_sort_field "dct_title_sort desc", label: "Title (Z-A)"
+    config.add_sort_field 'score desc, dct_title_sort asc', label: 'Relevance'
+    config.add_sort_field "#{Settings.FIELDS.INDEX_YEAR} desc, dct_title_sort asc", label: 'Year (Newest first)'
+    config.add_sort_field "#{Settings.FIELDS.INDEX_YEAR} asc, dct_title_sort asc", label: 'Year (Oldest first)'
+    config.add_sort_field 'dct_title_sort asc', label: 'Title (A-Z)'
+    config.add_sort_field 'dct_title_sort desc', label: 'Title (Z-A)'
 
     # If there are more than this many search results, no spelling ("did you
     # mean") suggestion is offered.
@@ -295,7 +302,7 @@ class CatalogController < ApplicationController
 
     # Nav actions from Blacklight
     # config.add_nav_action(:bookmark, partial: "blacklight/nav/bookmark", if: :render_bookmarks_control?)
-    config.add_nav_action(:search_history, partial: "blacklight/nav/search_history")
+    config.add_nav_action(:search_history, partial: 'blacklight/nav/search_history')
 
     # Tools from Blacklight
     config.add_results_collection_tool(:sort_widget)
@@ -306,10 +313,18 @@ class CatalogController < ApplicationController
     # config.add_show_tools_partial(:sms, if: :render_sms_action?, callback: :sms_action, validator: :validate_sms_params)
 
     # Custom tools for GeoBlacklight
-    config.add_show_tools_partial :metadata, if: proc { |_context, _config, options| options[:document] && (Settings.METADATA_SHOWN & options[:document].references.refs.map(&:type).map(&:to_s)).any? }
-    config.add_show_tools_partial :carto, partial: "carto", if: proc { |_context, _config, options| options[:document] && options[:document].carto_reference.present? }
-    config.add_show_tools_partial :arcgis, partial: "arcgis", if: proc { |_context, _config, options| options[:document] && options[:document].arcgis_urls.present? }
-    config.add_show_tools_partial :data_dictionary, partial: "data_dictionary", if: proc { |_context, _config, options| options[:document] && options[:document].data_dictionary_download.present? }
+    config.add_show_tools_partial :metadata, if: proc { |_context, _config, options|
+      options[:document] && (Settings.METADATA_SHOWN & options[:document].references.refs.map(&:type).map(&:to_s)).any?
+    }
+    config.add_show_tools_partial :carto, partial: 'carto', if: proc { |_context, _config, options|
+      options[:document] && options[:document].carto_reference.present?
+    }
+    config.add_show_tools_partial :arcgis, partial: 'arcgis', if: proc { |_context, _config, options|
+      options[:document] && options[:document].arcgis_urls.present?
+    }
+    config.add_show_tools_partial :data_dictionary, partial: 'data_dictionary', if: proc { |_context, _config, options|
+      options[:document] && options[:document].data_dictionary_download.present?
+    }
 
     # Configure basemap provider for GeoBlacklight maps (uses https only basemap
     # providers with open licenses)
@@ -324,11 +339,11 @@ class CatalogController < ApplicationController
     # 'openstreetmapHot'
     # 'openstreetmapStandard'
 
-    config.basemap_provider = "openstreetmapStandard"
+    config.basemap_provider = 'openstreetmapStandard'
 
     # Configuration for autocomplete suggestor
     config.autocomplete_enabled = true
-    config.autocomplete_path = "suggest"
+    config.autocomplete_path = 'suggest'
   end
 
   def web_services

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,13 +1,17 @@
+# frozen_string_literal: true
+
 module ApplicationHelper
   extend Deprecation
-  
+
   ##
   # Link to the previous document in the current search context
   #
   # Custom method to override link_to_previous_document so we can change its classes to match Bootstrap's pagination component
   def ual_link_to_previous_document(previous_document, classes: 'previous page-link', **addl_link_opts)
-    link_opts = session_tracking_params(previous_document, search_session['counter'].to_i - 1).merge(class: classes, rel: 'prev').merge(addl_link_opts)
-    link_to_unless previous_document.nil?, raw(t('views.pagination.previous')), url_for_document(previous_document), link_opts do
+    link_opts = session_tracking_params(previous_document, search_session['counter'].to_i - 1).merge(class: classes,
+                                                                                                     rel: 'prev').merge(addl_link_opts)
+    link_to_unless previous_document.nil?, raw(t('views.pagination.previous')), url_for_document(previous_document),
+                   link_opts do
       tag.span raw(t('views.pagination.previous')), class: 'previous page-link'
     end
   end
@@ -18,7 +22,8 @@ module ApplicationHelper
   #
   # Custom method to override link_to_next_document so we can change its classes to match Bootstrap's pagination component
   def ual_link_to_next_document(next_document, classes: 'next page-link', **addl_link_opts)
-    link_opts = session_tracking_params(next_document, search_session['counter'].to_i + 1).merge(class: classes, rel: 'next').merge(addl_link_opts)
+    link_opts = session_tracking_params(next_document, search_session['counter'].to_i + 1).merge(class: classes,
+                                                                                                 rel: 'next').merge(addl_link_opts)
     link_to_unless next_document.nil?, raw(t('views.pagination.next')), url_for_document(next_document), link_opts do
       tag.span raw(t('views.pagination.next')), class: 'next page-link'
     end
@@ -48,13 +53,10 @@ module ApplicationHelper
                end
     label = opts.delete(:label)
 
-    if link_url =~ /bookmarks/
-      label ||= t('blacklight.back_to_bookmarks').html_safe
-    end
+    label ||= t('blacklight.back_to_bookmarks').html_safe if link_url =~ /bookmarks/
 
     label ||= t('blacklight.back_to_search').html_safe
 
     link_to label, link_url, opts
   end
-  
 end

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ApplicationJob < ActiveJob::Base
   # Automatically retry jobs that encountered a deadlock
   # retry_on ActiveRecord::Deadlocked

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,6 @@
+# frozen_string_literal: true
+
 class ApplicationMailer < ActionMailer::Base
-  default from: "from@example.com"
-  layout "mailer"
+  default from: 'from@example.com'
+  layout 'mailer'
 end

--- a/app/models/acknowledged_user.rb
+++ b/app/models/acknowledged_user.rb
@@ -1,4 +1,6 @@
+# frozen_string_literal: true
+
 class AcknowledgedUser < ApplicationRecord
-    has_many :acknowledgments, dependent: :destroy
-    validates :netid, presence: true, uniqueness: true
+  has_many :acknowledgments, dependent: :destroy
+  validates :netid, presence: true, uniqueness: true
 end

--- a/app/models/acknowledgment.rb
+++ b/app/models/acknowledgment.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Acknowledgment < ApplicationRecord
   belongs_to :acknowledged_users
 end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
 end

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class SearchBuilder < Blacklight::SearchBuilder
   include Blacklight::Solr::SearchBuilderBehavior
   include Geoblacklight::SuppressedRecordsSearchBehavior

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -3,7 +3,7 @@
 # Represents a single document returned from Solr
 class SolrDocument
   include Blacklight::Solr::Document
- include Geoblacklight::SolrDocument
+  include Geoblacklight::SolrDocument
 
   # self.unique_key = 'id'
   self.unique_key = Settings.FIELDS.UNIQUE_KEY

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,6 @@
-class User < ApplicationRecord
+# frozen_string_literal: true
 
+class User < ApplicationRecord
   # Connects this user object to Blacklights Bookmarks.
   include Blacklight::User
   # Include default devise modules. Others available are:


### PR DESCRIPTION
This pull request applies Rubocop formatting to the `app` directory of the project(partially fixed some files, but, there are many other files that require manual updates).  This improves code readability and consistency, making it easier for developers to understand, maintain, and collaborate on the codebase. Rubocop can be configured as part of the CI pipeline on commits. It's useful not only for code formatting, but, might prevent security vulnerabilities as well.

For more info: https://github.com/rubocop/rubocop
